### PR TITLE
Implement collect_tokens function

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,1 +1,7 @@
-let () = print_endline "Hello, World!"
+open Monkey
+open Core
+
+let () = 
+  let input = "();,{}" in
+  let tokens = Lexer.collect_tokens input |> List.map ~f:(Token.show) in
+  List.iter ~f:print_endline tokens

--- a/lib/lexer.mli
+++ b/lib/lexer.mli
@@ -1,4 +1,6 @@
 type t
+
 val init : string -> t
 val next_token : t -> t * Token.t option
-val show: t -> string
+val show : t -> string
+val collect_tokens : string -> Token.t list


### PR DESCRIPTION
There is a bug where given an "+()" instead of the expected -> [Plus; LParen; RParen] it gives -> [Plus; Plust; LParen; RParen] in other words it repeats whatever the first token it recognizes is. I suspect that is a bug in either the collect_tokens function or the advance function that advances the lexer. An easy fix would be to take off the head of the list of the collect_tokens function after it's been computed. However, seems like a bandaid solution. Will investigate this later.